### PR TITLE
Functionality to add extra headers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.4
   - 5.5
   - 5.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev
+  - php composer.phar install
 
 script:
   - bin/phpunit --group read-only test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
+  - 5.5
+  - 5.6
 
 before_script:
   - wget http://getcomposer.org/composer.phar

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,13 @@
     }
   ],
   "require": {
-    "php": ">=5.2",
+    "php": ">=5.4",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "3.7.*"
+    "phpunit/phpunit": "4.7.*"
   },
   "config": {
     "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=5.4",
+    "php": ">=5.5",
     "ext-curl": "*",
     "ext-json": "*",
     "ext-mbstring": "*"

--- a/lib/TraackrApi.php
+++ b/lib/TraackrApi.php
@@ -43,6 +43,8 @@ final class TraackrApi {
 
    private static $customerKey = '';
 
+   private static $extraHeaders = array();
+
    private static $jsonOutput = false;
 
    private static $logger = null;
@@ -90,6 +92,20 @@ final class TraackrApi {
       self::$customerKey = $key;
 
    } // End function setCustomerKey()
+
+
+   public static function setExtraHeaders($headers) {
+      
+      self::$extraHeaders = $headers;
+
+   } // End function setExtraHeaders()
+   
+
+   public static function getExtraHeaders() {
+
+      return self::$extraHeaders;
+
+   } // End function getExtraHeaders()
 
 
    public static function isJsonOutput() {

--- a/lib/TraackrApi.php
+++ b/lib/TraackrApi.php
@@ -96,7 +96,17 @@ final class TraackrApi {
 
    public static function setExtraHeaders($headers) {
       
-      self::$extraHeaders = $headers;
+      if ( is_string($headers) ) {
+         self::$extraHeaders = array($headers);
+         return true;
+      }
+      else if ( is_array($headers) ) {
+         self::$extraHeaders = $headers;
+         return true;
+      }
+      else {
+         return false;
+      }
 
    } // End function setExtraHeaders()
    

--- a/lib/TraackrApi/TraackrApiObject.php
+++ b/lib/TraackrApi/TraackrApiObject.php
@@ -9,6 +9,25 @@ abstract class TraackrApiObject {
 
    private $curl;
 
+   // Headers passed with each request
+   private $curl_headers  = array(
+      // Adding some headers to force no caching.
+      "Cache-Control: no-cache",
+      "Pragma: no-cache",
+      //some proxies throw a "417" error for CURL calls; CURL is supposed
+      //to retry the call, but doesn't, so just set "Expect" to nothing to
+      //avoid this (this ensures that CURL doesn't set it to an unrecognized
+      //value under the covers)
+      "Expect:",
+
+      // Sets request headers. This are important to be UTF-8 compliant
+      // To ensure that POST parameters (passed in the body) are UTF-8 encoded:
+      "Content-Type: application/x-www-form-urlencoded;charset=utf-8",
+      // To Ensure the server sends back UTF-8 text
+      "Accept-Charset: utf-8",
+      "Accept: text/plain"
+   );
+
    public function __construct() {
 
       // init cURL
@@ -18,26 +37,8 @@ abstract class TraackrApiObject {
       // Set timeouts
       curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, self::$connectionTimeout);
       curl_setopt($this->curl, CURLOPT_TIMEOUT, self::$timeout);
-
-      $curl_headers = array(
-         // Adding some headers to force no caching.
-         "Cache-Control: no-cache",
-         "Pragma: no-cache",
-         //some proxies throw a "417" error for CURL calls; CURL is supposed
-         //to retry the call, but doesn't, so just set "Expect" to nothing to
-         //avoid this (this ensures that CURL doesn't set it to an unrecognized
-         //value under the covers)
-         "Expect:",
-
-         // Sets request headers. This are important to be UTF-8 compliant
-         // To ensure that POST parameters (passed in the body) are UTF-8 encoded:
-         "Content-Type: application/x-www-form-urlencoded;charset=utf-8",
-         // To Ensure the server sends back UTF-8 text
-         "Accept-Charset: utf-8",
-         "Accept: text/plain"
-        );
-        curl_setopt($this->curl, CURLOPT_HTTPHEADER, $curl_headers);
-        curl_setopt($this->curl, CURLOPT_ENCODING , "gzip;q=1.0, deflate;q=0.5, identity;q=0.1");
+      // Set encodings
+      curl_setopt($this->curl, CURLOPT_ENCODING , "gzip;q=1.0, deflate;q=0.5, identity;q=0.1");
 
    } // End constructor
 
@@ -101,6 +102,10 @@ abstract class TraackrApiObject {
 
 
    private function call($decode) {
+
+      // Prep headers
+      curl_setopt($this->curl, CURLOPT_HTTPHEADER,
+         array_merge($this->curl_headers, TraackrApi::getExtraHeaders()) );
 
       // Make the call!
       $curl_exec = curl_exec($this->curl);

--- a/test/TraackrApiTest.php
+++ b/test/TraackrApiTest.php
@@ -1,0 +1,43 @@
+<?php
+
+class TraackrApiTest extends PHPUnit_Framework_TestCase {
+
+   private $singleHeader = "X-TraackrTest: xxxxx";
+
+   private $arrayHeader = array(
+   "X-TraackrTest1: xxxxx",
+   "X-TraackrTest2: yyyyy");
+
+
+   /**
+    * @group read-only
+    */
+   public function testSetExtraHeaders() {
+
+      $this->assertFalse(Traackr\TraackrApi::setExtraHeaders(1));
+      $this->assertTrue(Traackr\TraackrApi::setExtraHeaders($this->singleHeader));
+      $this->assertTrue(Traackr\TraackrApi::setExtraHeaders($this->arrayHeader));
+
+   } // End function testSetExtraHeaders
+
+   /**
+    * @group read-only
+    */
+   public function testGetExtraHeaders() {
+
+      Traackr\TraackrApi::setExtraHeaders($this->singleHeader);
+      $h = Traackr\TraackrApi::getExtraHeaders();
+      $this->assertInternalType('array', $h);
+      $this->assertEquals(1, sizeof($h));
+      $this->assertContains($this->singleHeader, $h);
+
+      Traackr\TraackrApi::setExtraHeaders($this->arrayHeader);
+      $h = Traackr\TraackrApi::getExtraHeaders();
+      $this->assertInternalType('array', $h);
+      $this->assertEquals(2, sizeof($h));
+      $this->assertContains($this->arrayHeader[0], $h);
+      $this->assertContains($this->arrayHeader[1], $h);
+      
+   } // End function testGetExtraHeaders
+
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -8,3 +8,5 @@ require_once(dirname(__FILE__) . '/../lib/TraackrApi.php');
 if ( !isset($_ENV['TRAACKR_API_KEY']) ) {
    Traackr\TraackrApi::setApiKey('5adab9df789c2147116881f36785f6c3');
 }
+
+Traackr\TraackrApi::setExtraHeaders(array("X-TraackrApp-Session: TraackrAPI-UnitTest"));


### PR DESCRIPTION
Added functionality to define custom HTTP headers that can be passed
during API calls. This is done with the TraackrAPI::setExtraHeaders()
function.