### PR TITLE
Support for new API endpoints

### DIFF
--- a/lib/TraackrApi/Influencers.php
+++ b/lib/TraackrApi/Influencers.php
@@ -4,9 +4,13 @@ namespace Traackr;
 
 class Influencers extends TraackrApiObject {
 
-   /*
-    * Get an influencer data.
+   /**
+    * Get an influencer's data
     *
+    * @param string $uid
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
     */
    public static function show($uid, $p = array('with_channels' => false)) {
 
@@ -17,7 +21,7 @@ class Influencers extends TraackrApiObject {
       // API Object
       $inf = new Influencers();
 
-      //Sanatize default values
+      //Sanitize default values
       $p['with_channels'] = $inf->convertBool($p, 'with_channels');
 
       // Add customer key + check required params
@@ -28,11 +32,15 @@ class Influencers extends TraackrApiObject {
 
       return $inf->get(TraackrApi::$apiBaseUrl.'influencers/show/'.$uid, $p);
 
-   } // End function show()
+   }
 
-
-   /*
-    * Returns an infuencer's connections
+   /**
+    * Returns an influencer's connections
+    *
+    * @param string $uid
+    * @param string $direction
+    * @return bool|mixed
+    * @throws MissingParameterException
     */
    public static function connections($uid, $direction = '') {
 
@@ -46,10 +54,14 @@ class Influencers extends TraackrApiObject {
       return $inf->get(TraackrApi::$apiBaseUrl.'influencers/connections/'.$direction.$uid,
          array());
 
-   } // End function connections()
+   }
 
-   /*
-    * Lopokup Influencer by a Twitter handle
+   /**
+    * Lookup Influencer by a Twitter handle
+    *
+    * @param string $username
+    * @return bool|mixed
+    * @throws MissingParameterException
     */
    public static function lookupTwitter($username) {
 
@@ -61,11 +73,14 @@ class Influencers extends TraackrApiObject {
       return $inf->get(TraackrApi::$apiBaseUrl.'influencers/lookup/twitter/'.$username,
          array());
 
-   } // End function lookupTwitter
+   }
 
-
-   /*
+   /**
     * Add Twitter account
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
     */
    public static function addTwitter($p = array()) {
 
@@ -81,11 +96,14 @@ class Influencers extends TraackrApiObject {
 
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/add/twitter', $p);
 
-   } // End function addTwitter()
+   }
 
-
-   /*
+   /**
     * Add influencer by name and primary URL
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
     */
    public static function add($p = array()) {
 
@@ -101,14 +119,20 @@ class Influencers extends TraackrApiObject {
 
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/add', $p);
 
-   } // End function add()
+   }
 
-
+   /**
+    * Add a tag to an influencer
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
    public static function tagAdd($p = array('strict' => false)) {
 
       $inf = new Influencers();
 
-      // Sanatize default values
+      // Sanitize default values
       $p['strict'] = $inf->convertBool($p, 'strict');
 
       $p = $inf->addCustomerKey($p);
@@ -122,14 +146,20 @@ class Influencers extends TraackrApiObject {
 
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/tag/add', $p);
 
-   } // End function tagAdd()
+   }
 
-
+   /**
+    * Remove a tag from an influencer
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
    public static function tagRemove($p = array('all' => false)) {
 
       $inf = new Influencers();
 
-      // Sanatize default values
+      // Sanitize default values
       $p['all'] = $inf->convertBool($p, 'all');
 
       $p = $inf->addCustomerKey($p);
@@ -151,14 +181,20 @@ class Influencers extends TraackrApiObject {
 
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/tag/remove', $p);
 
-   } // End function tagRemove()
+   }
 
-
+   /**
+    * Get the tags on an influencer
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
    public static function tagList($p = array('is_prefix' => false)) {
 
       $inf = new Influencers();
 
-      // Sanatize default values
+      // Sanitize default values
       $p['is_prefix'] = $inf->convertBool($p, 'is_prefix');
 
       $p = $inf->addCustomerKey($p);
@@ -166,9 +202,14 @@ class Influencers extends TraackrApiObject {
 
       return $inf->get(TraackrApi::$apiBaseUrl.'influencers/tag/list', $p);
 
-   } // End function tagList()
+   }
 
-
+   /**
+    * Lookup influencers
+    *
+    * @param array $p
+    * @return bool|mixed
+    */
    public static function lookup($p = array(
       'is_tag_prefix' => false,
       'gender' => 'all',
@@ -180,7 +221,7 @@ class Influencers extends TraackrApiObject {
 
       $inf = new Influencers();
 
-      // Sanatize default values
+      // Sanitize default values
       $p['is_tag_prefix'] = $inf->convertBool($p, 'is_tag_prefix');
       $p['enable_tags_aggregation'] = $inf->convertBool($p, 'enable_tags_aggregation');
       $p['enable_country_aggregation'] = $inf->convertBool($p, 'enable_country_aggregation');
@@ -207,19 +248,26 @@ class Influencers extends TraackrApiObject {
       }
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/lookup', $p);
 
-   } // End function lookup()
+   }
 
+   /**
+    * Search for influencers
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
    public static function search($p = array(
       'is_tag_prefix' => false,
       'gender' => 'all',
       'lang' => 'all',
       'enable_audience_aggregation' => false,
-      'enable_country_aggregation' => false,      
+      'enable_country_aggregation' => false,
       'count' => 25)) {
 
       $inf = new Influencers();
 
-      // Sanatize default values
+      // Sanitize default values
       $p['is_tag_prefix'] = $inf->convertBool($p, 'is_tag_prefix');
       $p['enable_audience_aggregation'] = $inf->convertBool($p, 'enable_audience_aggregation');
       $p['enable_country_aggregation'] = $inf->convertBool($p, 'enable_country_aggregation');
@@ -260,6 +308,40 @@ class Influencers extends TraackrApiObject {
       }
       return $inf->post(TraackrApi::$apiBaseUrl.'influencers/search', $p);
 
-   } // End function search()
+   }
 
-} // End class Influencer
+   /**
+    * Add a channel URL to an influencer
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
+   public static function channelsAdd($p = []) {
+
+      $inf = new Influencers();
+
+      $inf->checkRequiredParams($p, ['influencer', 'url']);
+
+      return $inf->post(TraackrApi::$apiBaseUrl.'influencers/channels/add', $p);
+
+   }
+
+   /**
+    * Report an influencer
+    *
+    * @param array $p
+    * @return bool|mixed
+    * @throws MissingParameterException
+    */
+   public static function report($p = []) {
+
+      $inf = new Influencers();
+
+      $inf->checkRequiredParams($p, ['influencer', 'url']);
+
+      return $inf->post(TraackrApi::$apiBaseUrl.'influencers/report', $p);
+
+   }
+
+}

--- a/test/Influencers/InfluencersTest.php
+++ b/test/Influencers/InfluencersTest.php
@@ -7,6 +7,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
    private $infTag2 = 'inf-tag-test';
    private $infTagUTF8 = 'påverkare marknadsföring traackr-api-test';
    private $infName = 'David Chancogne';
+   private $channel = 'http://traackr.com/blog';
 
    private $infUid2 = 'ae1955b0f92037c895e5bfdd259a1304';
 
@@ -31,18 +32,16 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          // Ignore
       }
 
-      // Ensure outout is PHP by default
+      // Ensure output is PHP by default
       Traackr\TraackrApi::setJsonOutput(false);
 
-   } // End function setUp()
+   }
 
    public function tearDown() {
 
       Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
 
-   } // End function tearDown()
-
-
+   }
 
    public function testShowWithTags() {
 
@@ -79,7 +78,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertEquals($this->infName, $inf['influencer'][$this->infUid]['name'],
          'Incorrect name');
 
-   } // End function testShowWithTags()
+   }
 
    /**
     * @group read-only
@@ -134,7 +133,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertCount(2, $infs['influencer'],
          'Incorrected number of influencers returned');
 
-   } // End function testShow()
+   }
 
    /**
     * @group read-only
@@ -144,7 +143,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
 
       Traackr\Influencers::show('00000');
 
-   } // End function testShowNotFound()
+   }
 
    /**
     * @group read-only
@@ -154,8 +153,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
 
       Traackr\Influencers::show('');
 
-   } // End function testShowMissingParameter()
-
+   }
 
    /**
     * @group read-only
@@ -241,8 +239,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertLessThanOrEqual(20, sizeof($connections['influencer'][$this->infUid]['connections_to']),
          'Different number of conections_to then expected');
 
-
-   } // End function testConnections
+   }
 
    /**
     * @group read-only
@@ -253,8 +250,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       Traackr\Influencers::connections('to', '00000');
       Traackr\Influencers::connections('from', '00000');
 
-   } // End function testConnectionsNotFound()
-
+   }
 
    /**
     * @group read-only
@@ -306,7 +302,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          json_encode($twitter['influencer']['dchancogne'])
       );
 
-   } // End function testLookupTwitter()
+   }
 
    /**
     * @group read-only
@@ -316,8 +312,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
 
       Traackr\Influencers::lookupTwitter('000RandomHandle000');
 
-   } // End function testLookupTwitterNotFound()
-
+   }
 
    public function testTagAdd() {
 
@@ -393,7 +388,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          'tags' => $this->infTag));
 
 
-   } // End function testTagAdd()
+   }
 
    public function testTagRemove() {
 
@@ -427,7 +422,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertCount(0, $inf['influencer'][$this->infUid]['tags']);
       $this->assertTrue(!in_array($this->infTag, $inf['influencer'][$this->infUid]['tags']));
 
-   } // End function testTagRemove()
+   }
 
    public function testTagList() {
 
@@ -459,7 +454,41 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          'influencers' => array($this->infUid, $this->infUid2),
          'tags' => array($this->infTag, $this->infTag.'inf2')));
 
-   } // End function testTagList()
+   }
+
+   /**
+    * @group experimental
+    */
+   public function testChannelsAdd() {
+      $ownership = 'reference';
+
+      $result = Traackr\Influencers::channelsAdd([
+          'influencer' => $this->infUid,
+          'url' => $this->channel,
+          'ownership' => $ownership
+      ]);
+
+      $this->assertNotEmpty($result['uid']);
+      $this->assertEquals($this->infUid, $result['influencer_uid']);
+      $this->assertEquals('BLOG', $result['platform']);
+   }
+
+   /**
+    * @group experimental
+    */
+   public function testReport() {
+      $reportText = 'Testing PHP client...';
+
+      $result = Traackr\Influencers::report([
+          'influencer' => $this->infUid,
+          'url' => $this->channel,
+          'reportText' => $reportText
+      ]);
+
+      $this->assertEquals($this->infUid, $result['influencer_uid']);
+      $this->assertEquals($this->channel, $result['url']);
+      $this->assertEquals($reportText, $result['reportText']);
+   }
 
    /**
     * @group read-only
@@ -534,7 +563,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertGreaterThan(0, $inf['influencers'], 'No results found');
       $this->assertEquals(2, count($inf['influencers']), 'Two results should have been found');
 
-   } // End function testLookup()
+   }
 
    public function testLookup() {
 
@@ -573,7 +602,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          'influencers' => array($this->infUid, $this->infUid2),
          'tags' => array($this->infTag, $this->infTag2) ));
 
-   } // End function testLookupRO()
+   }
 
    /**
     * @group read-only
@@ -609,7 +638,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertArrayHasKey('audienceStats', $inf['aggregations'], 'Audience Aggregation: Audience Stats key missing');
       $this->assertNotEmpty($inf['aggregations']['audienceStats'], 'No audience aggregations found');
 
-      $inf = Traackr\Influencers::search(array('keywords' => 'xxxaaaxxx'));      
+      $inf = Traackr\Influencers::search(array('keywords' => 'xxxaaaxxx'));
       $this->assertCount(0, $inf['influencers'], 'Results found');
 
       // Search Email
@@ -621,8 +650,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $inf = Traackr\Influencers::search(array('keywords' => 'traackr', 'emails' => 'dchancogne@traackr.com'));
       $this->assertGreaterThan(0, $inf['influencers'], 'No results found');
       $this->assertEquals('David Chancogne', $inf['influencers'][0]['name'], 'Name does not match expected result by email address: dchancogne@traackr.com');
-   } // End function testSearchRO()
-
+   }
 
    public function testSearch() {
 
@@ -651,6 +679,6 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
          'influencers' => array($this->infUid, $this->infUid2),
          'tags' => array($this->infTag, $this->infTag2) ));
 
-   } // End function testSearch()
+   }
 
-} // End class InfluencersTest
+}

--- a/test/Influencers/InfluencersTest.php
+++ b/test/Influencers/InfluencersTest.php
@@ -456,9 +456,6 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
 
    }
 
-   /**
-    * @group experimental
-    */
    public function testChannelsAdd() {
       $ownership = 'reference';
 
@@ -471,11 +468,12 @@ class InfluencersTest extends PHPUnit_Framework_TestCase {
       $this->assertNotEmpty($result['uid']);
       $this->assertEquals($this->infUid, $result['influencer_uid']);
       $this->assertEquals('BLOG', $result['platform']);
+      $this->assertNotEmpty($result['ownership']);
+      $this->assertNotEmpty($result['percentContribution']);
+      $this->assertNotEmpty($result['toBeValidated']);
+      $this->assertNotEmpty($result['toBeRemoved']);
    }
 
-   /**
-    * @group experimental
-    */
    public function testReport() {
       $reportText = 'Testing PHP client...';
 


### PR DESCRIPTION
The API recently added the endpoints `/influencers/channels/add` and `/influencers/report`. This adds support to the wrapper for these endpoints along with the appropriate tests.