### PR TITLE
BI-8084: Support ssl-verify-peer skip to support internal access.

### DIFF
--- a/lib/TraackrApi.php
+++ b/lib/TraackrApi.php
@@ -39,7 +39,7 @@ final class TraackrApi {
 
    private static $apiKey;
 
-   public static $apiBaseUrl = 'http://api.traackr.com/1.0/';
+   public static $apiBaseUrl = 'https://api.traackr.com/1.0/';
 
    private static $customerKey = '';
 

--- a/lib/TraackrApi/TraackrApiObject.php
+++ b/lib/TraackrApi/TraackrApiObject.php
@@ -6,6 +6,7 @@ abstract class TraackrApiObject
 {
     public static $connectionTimeout = 10;
     public static $timeout = 10;
+    public static $sslVerifyPeer = true;
 
     private $curl;
 
@@ -41,6 +42,8 @@ abstract class TraackrApiObject
         curl_setopt($this->curl, CURLOPT_TIMEOUT, self::$timeout);
         // Set encodings
         curl_setopt($this->curl, CURLOPT_ENCODING, 'gzip;q=1.0, deflate;q=0.5, identity;q=0.1');
+        // SSL verify peer
+        curl_setopt($this->curl, CURLOPT_SSL_VERIFYPEER, self::$sslVerifyPeer);
     }
 
     protected function checkRequiredParams($params, $fields)


### PR DESCRIPTION
This is to support internal access to our Core API.