### PR TITLE
REP-409: Allowing cust-keys to handle arrays.

### DIFF
--- a/lib/TraackrApi.php
+++ b/lib/TraackrApi.php
@@ -89,7 +89,11 @@ final class TraackrApi {
 
    public static function setCustomerKey($key) {
 
-      self::$customerKey = $key;
+      if (is_array($key)) {
+         self::$customerKey = implode(',', $key);
+      } else {
+         self::$customerKey = $key;
+      }
 
    } // End function setCustomerKey()
 

--- a/lib/TraackrApi/TraackrApiObject.php
+++ b/lib/TraackrApi/TraackrApiObject.php
@@ -56,11 +56,19 @@ abstract class TraackrApiObject
         }
     }
 
+    /**
+     * influencers/lookup & /search and posts/lookup and /search now support multiple
+     * customer-keys, so this function massages arrays of them.
+     */
     protected function addCustomerKey(&$params)
     {
         $key = TraackrApi::getCustomerKey();
         if (!empty($key) && empty($params[PARAM_CUSTOMER_KEY])) {
             $params[PARAM_CUSTOMER_KEY] = $key;
+        }
+
+        if (!empty($params[PARAM_CUSTOMER_KEY]) && is_array($params[PARAM_CUSTOMER_KEY])) {
+            $params[PARAM_CUSTOMER_KEY] = implode(',', $params[PARAM_CUSTOMER_KEY]);
         }
 
         return $params;


### PR DESCRIPTION
Pretty simple change to support an array of customer-keys. Note that even though we don't support this on every API call, it's handled generically. So it's really up to the caller to make sure they are using it right.

Note that this wasn't a blocker; we could've just forced the PHP client caller to send a comma-delimited string, but since we do do some array-massaging elsewhere in the client (for tags, etc.), figured we should do it for this.