### PR TITLE
EMP-161 Allow social data search param as only parameter

### DIFF
--- a/lib/TraackrApi/Influencers.php
+++ b/lib/TraackrApi/Influencers.php
@@ -347,8 +347,15 @@ class Influencers extends TraackrApiObject
         } catch (MissingParameterException $e) {
         }
 
-        if (!$hasContentCriteria && !$hasAudienceCriteria) {
-            throw new MissingParameterException('Missing parameter: must provide keywords or audience parameter');
+        $hasSocialDataSearchCriteria = false;
+        try {
+            $inf->checkRequiredParams($p, ['social_data_audience_search_criteria']);
+            $hasSocialDataSearchCriteria = true;
+        } catch (MissingParameterException $e) {
+        }
+
+        if (!$hasContentCriteria && !$hasAudienceCriteria && !$hasSocialDataSearchCriteria) {
+            throw new MissingParameterException('Missing parameter: must provide keywords, audience, or social data search parameter');
         }
 
         // support for multi params


### PR DESCRIPTION
Core previously required the 'audience' or 'keywords' parameters to be set when using the search endpoint. 
With the addition of the social data search parameter that has changed. 
Now 'audience', 'keywords' OR 'social_data_audience_search_criteria' are acceptable. 
This PR updates the API to reflect this.