### PR TITLE
EMP-990 add sanitization for enable_regional_country_exclusions

### DIFF
--- a/lib/TraackrApi/Influencers.php
+++ b/lib/TraackrApi/Influencers.php
@@ -302,6 +302,10 @@ class Influencers extends TraackrApiObject
             $p['emails'] = is_array($p['emails']) ?
                 implode(',', $p['emails']) : $p['emails'];
         }
+        // include parameter if set (true by default)
+        if (isset($p['enable_regional_country_exclusions'])) {
+            $p['enable_regional_country_exclusions'] = $inf->convertBool($p, 'enable_regional_country_exclusions');
+        }
         return $inf->post(TraackrApi::$apiBaseUrl . 'influencers/lookup', $p);
     }
 
@@ -411,6 +415,10 @@ class Influencers extends TraackrApiObject
         if (isset($p['posts_exclusive'])) {
             $p['posts_exclusive'] = is_array($p['posts_exclusive']) ?
                 implode(',', $p['posts_exclusive']) : $p['posts_exclusive'];
+        }
+        // include parameter if set (true by default)
+        if (isset($p['enable_regional_country_exclusions'])) {
+            $p['enable_regional_country_exclusions'] = $inf->convertBool($p, 'enable_regional_country_exclusions');
         }
         return $inf->post(TraackrApi::$apiBaseUrl . 'influencers/search', $p);
     }

--- a/lib/TraackrApi/Posts.php
+++ b/lib/TraackrApi/Posts.php
@@ -58,6 +58,11 @@ class Posts extends TraackrApiObject {
          $p['posts_exclusive'] = is_array($p['posts_exclusive']) ?
                implode(',', $p['posts_exclusive']) : $p['posts_exclusive'];
       }
+      
+      // include parameter if set (true by default)
+      if (isset($p['enable_regional_country_exclusions'])) {
+         $p['enable_regional_country_exclusions'] = $posts->convertBool($p, 'enable_regional_country_exclusions');
+      }
       return $posts->post(TraackrApi::$apiBaseUrl.'posts/lookup', $p);
 
    }
@@ -125,6 +130,11 @@ class Posts extends TraackrApiObject {
       if (isset($p['posts_exclusive'])) {
          $p['posts_exclusive'] = is_array($p['posts_exclusive']) ?
                implode(',', $p['posts_exclusive']) : $p['posts_exclusive'];
+      }
+
+      // include parameter if set (true by default)
+      if (isset($p['enable_regional_country_exclusions'])) {
+         $p['enable_regional_country_exclusions'] = $posts->convertBool($p, 'enable_regional_country_exclusions');
       }
       return $posts->post(TraackrApi::$apiBaseUrl.'posts/search', $p);
 


### PR DESCRIPTION
While testing EMP-990 we noticed the logs were showing the inclusion of the enable_regional_country_exclusions = false where expected, but the results returned were as if the flag wasn't passed. We believe that the traackr api is either omitting the param/not properly sanitizing the param. 