### PR TITLE
fix: SUPP-56 upgrade phpunit to ^8.5.52 to address CVE-2026-24765

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "guzzlehttp/guzzle": "^6.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8.*"
+    "phpunit/phpunit": "^8.5.52"
   },
   "config": {
     "bin-dir": "bin",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,2 +1,7 @@
 <phpunit bootstrap="test/bootstrap.php" colors="true">
+  <testsuites>
+    <testsuite name="traackr-api-php">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/AccountMgmt/AccountMgmtTest.php
+++ b/test/AccountMgmt/AccountMgmtTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class AccountMgmtTest extends PHPUnit_Framework_TestCase {
+class AccountMgmtTest extends PHPUnit\Framework\TestCase {
 
    private $infUid = '1395be8293373465ab172b8b1b677e31';
    private $infTag = 'traackr-api-test';
@@ -10,7 +10,7 @@ class AccountMgmtTest extends PHPUnit_Framework_TestCase {
    private $savedCustomerKey;
 
 
-   public function setUp() {
+   public function setUp(): void {
 
       $this->savedCustomerKey = Traackr\TraackrApi::getCustomerKey();
 
@@ -19,7 +19,7 @@ class AccountMgmtTest extends PHPUnit_Framework_TestCase {
 
    } // End function setUp()
 
-   public function tearDown() {
+   public function tearDown(): void {
 
       Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
 
@@ -71,11 +71,9 @@ class AccountMgmtTest extends PHPUnit_Framework_TestCase {
 
    } // End function testTagList()
 
-   /**
-    * @expectedException Traackr\InvalidCustomerKeyException
-    */
    public function testSTagListInvalidCustomerKey() {
 
+      $this->expectException(\Traackr\InvalidCustomerKeyException::class);
       Traackr\TraackrApi::setCustomerKey('xxxRandomInvalidCustomerKeyxxxx');
       Traackr\AccountMgmt::tagList();
 

--- a/test/Analysis/AnalysisTest.php
+++ b/test/Analysis/AnalysisTest.php
@@ -1,17 +1,17 @@
 <?php
 
-class AnalysisTest extends PHPUnit_Framework_TestCase {
+class AnalysisTest extends PHPUnit\Framework\TestCase {
 
    private $savedCustomerKey;
 
 
-   public function setUp() {
+   public function setUp(): void {
       $this->savedCustomerKey = Traackr\TraackrApi::getCustomerKey();
       // Ensure outout is PHP by default
       Traackr\TraackrApi::setJsonOutput(false);
    } // End function setUp()
 
-   public function tearDown() {
+   public function tearDown(): void {
       Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
    } // End functiuon tearDown()
 

--- a/test/Influencers/InfluencersTest.php
+++ b/test/Influencers/InfluencersTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class InfluencersTest extends PHPUnit_Framework_TestCase
+class InfluencersTest extends PHPUnit\Framework\TestCase
 {
     private $infUid = '1395be8293373465ab172b8b1b677e31';
     private $infTag = 'traackr-api-test';
@@ -17,7 +17,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
     private $savedCustomerKey;
 
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->savedCustomerKey = Traackr\TraackrApi::getCustomerKey();
 
@@ -40,7 +40,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
         Traackr\TraackrApi::setJsonOutput(false);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
     }
@@ -110,19 +110,19 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group read-only
-     * @expectedException Traackr\NotFoundException
      */
     public function testShowNotFound()
     {
+        $this->expectException(\Traackr\NotFoundException::class);
         Traackr\Influencers::show('00000');
     }
 
     /**
      * @group read-only
-     * @expectedException Traackr\MissingParameterException
      */
     public function testShowMissingParameter()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
         Traackr\Influencers::show('');
     }
 
@@ -254,28 +254,28 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
 
     /**
      * @group read-only
-     * @expectedException Traackr\MissingParameterException
      */
     public function testLookupSocialInvalidPlatformParameter()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
         Traackr\Influencers::lookupSocial('dchancogne', '');
     }
 
     /**
      * @group read-only
-     * @expectedException \UnexpectedValueException
      */
     public function testLookupSocialInvalidTypeParameter()
     {
+        $this->expectException(\UnexpectedValueException::class);
         Traackr\Influencers::lookupSocial('dchancogne', 'TWITTER', 'INVALID');
     }
 
     /**
      * @group read-only
-     * @expectedException Traackr\NotFoundException
      */
     public function testLookupSocialNotFound()
     {
+        $this->expectException(\Traackr\NotFoundException::class);
         Traackr\Influencers::lookupSocial('000RandomHandle000');
     }
 
@@ -311,11 +311,9 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($result['influencer'][$this->infTwitterId]['uid'], $this->infUid);
     }
 
-    /**
-     * @expectedException Traackr\MissingParameterException
-     */
     public function testAddSocialByUsernameAndUserId()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
         // this will fail and throw an expected exception
         Traackr\Influencers::addSocial([
             'username' => $this->infTwitterHandle,
@@ -324,33 +322,27 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
         ]);
     }
 
-    /**
-     * @expectedException Traackr\MissingParameterException
-     */
     public function testAddSocialMissingUserParam()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
         // this will fail and throw an expected exception
         Traackr\Influencers::addSocial([
             'platform' => 'TWITTER'
         ]);
     }
 
-    /**
-     * @expectedException Traackr\MissingParameterException
-     */
     public function testAddSocialMissingPlatformParam()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
         // this will fail and throw an expected exception
         Traackr\Influencers::addSocial([
             'username' => $this->infTwitterHandle
         ]);
     }
 
-    /**
-     * @expectedException Traackr\UnexpectedValueException
-     */
     public function testAddSocialInvalidPlatformParam()
     {
+        $this->expectException(\UnexpectedValueException::class);
         // this will fail and throw an expected exception
         Traackr\Influencers::addSocial([
             'username' => $this->infTwitterHandle,
@@ -714,11 +706,11 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
     /**
      * @group error-check
      * @group read-only
-     * @expectedException Traackr\MissingParameterException
-     * @expectedExceptionMessage Missing parameter: must provide keywords, audience, or social data search parameter
      */
     public function testSearchMissingRequiredParameter()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
+        $this->expectExceptionMessage('Missing parameter: must provide keywords, audience, or social data search parameter');
         Traackr\Influencers::search([]);
     }
 
@@ -833,11 +825,11 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
     /**
      * @group error-check
      * @group read-only
-     * @expectedException Traackr\MissingParameterException
-     * @expectedExceptionMessage Missing parameter: query
      */
     public function testQuickLookupMissingRequiredParameter()
     {
+        $this->expectException(\Traackr\MissingParameterException::class);
+        $this->expectExceptionMessage('Missing parameter: query');
         // this will fail and throw an expected exception
         Traackr\Influencers::quickLookup([]);
     }
@@ -862,7 +854,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
 
         $result = Traackr\Influencers::stream($params);
 
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertArrayHasKey('page_info', $result);
         $this->assertArrayHasKey('influencers', $result);
 
@@ -879,12 +871,10 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
         }
     }
 
-    /**
-     * @expectedException \UnexpectedValueException
-     * @expectedExceptionMessage Scoring mode ENGAGEMENT_RATE_V2 is not supported for streaming endpoint.
-     */
     public function testStreamWithInvalidScoringMode()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('Scoring mode ENGAGEMENT_RATE_V2 is not supported for streaming endpoint.');
         Traackr\Influencers::stream([
             'scoring_mode' => 'ENGAGEMENT_RATE_V2'
         ]);
@@ -899,7 +889,7 @@ class InfluencersTest extends PHPUnit_Framework_TestCase
         );
 
         $result = Traackr\Influencers::stream($params);
-  
+
         Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
      }
 }

--- a/test/Posts/PostsTest.php
+++ b/test/Posts/PostsTest.php
@@ -1,12 +1,12 @@
 <?php
 
-class PostsTest extends PHPUnit_Framework_TestCase {
+class PostsTest extends PHPUnit\Framework\TestCase {
 
    private $infUid = '1395be8293373465ab172b8b1b677e31';
 
    private $savedCustomerKey;
 
-   public function setUp() {
+   public function setUp(): void {
 
       $this->savedCustomerKey = Traackr\TraackrApi::getCustomerKey();
 
@@ -15,7 +15,7 @@ class PostsTest extends PHPUnit_Framework_TestCase {
 
    } // End function setUp()
 
-   public function tearDown() {
+   public function tearDown(): void {
 
       Traackr\TraackrApi::setCustomerKey($this->savedCustomerKey);
 
@@ -83,13 +83,13 @@ class PostsTest extends PHPUnit_Framework_TestCase {
 
       $result = Traackr\Posts::stream($params);
 
-      $this->assertInternalType('array', $result, 'The return method should be an array');
+      $this->assertIsArray($result, 'The return method should be an array');
       $this->assertArrayHasKey('page_info', $result, 'page_info is missing');
       $this->assertArrayHasKey('posts', $result, 'The "posts" key is missing');
 
       $postsGenerator = $result['posts'];
       $this->assertTrue(
-          is_array($postsGenerator) || $postsGenerator instanceof Traversable, 
+          is_array($postsGenerator) || $postsGenerator instanceof Traversable,
           'The value of the "posts" key should be iterable (Generator)'
       );
 
@@ -98,10 +98,10 @@ class PostsTest extends PHPUnit_Framework_TestCase {
          $found = true;
          $this->assertArrayHasKey('influencer_uid', $post, 'The post does not have influencer_uid');
          $this->assertArrayHasKey('url', $post, 'The post does not have url');
-         
-         break; 
+
+         break;
       }
-      
+
    }
 
    /**
@@ -123,7 +123,7 @@ class PostsTest extends PHPUnit_Framework_TestCase {
       $result = Traackr\Posts::stream($params);
 
       $this->assertArrayHasKey('posts', $result);
-      
+
       foreach ($result['posts'] as $post) {
          $this->assertEquals($this->infUid, $post['influencer_uid'], 'The post UID does not match');
          break;

--- a/test/TraackrApiTest.php
+++ b/test/TraackrApiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class TraackrApiTest extends PHPUnit_Framework_TestCase {
+class TraackrApiTest extends PHPUnit\Framework\TestCase {
 
    private $singleHeader = "X-TraackrTest: xxxxx";
 
@@ -27,17 +27,17 @@ class TraackrApiTest extends PHPUnit_Framework_TestCase {
 
       Traackr\TraackrApi::setExtraHeaders($this->singleHeader);
       $h = Traackr\TraackrApi::getExtraHeaders();
-      $this->assertInternalType('array', $h);
+      $this->assertIsArray($h);
       $this->assertEquals(1, sizeof($h));
       $this->assertContains($this->singleHeader, $h);
 
       Traackr\TraackrApi::setExtraHeaders($this->arrayHeader);
       $h = Traackr\TraackrApi::getExtraHeaders();
-      $this->assertInternalType('array', $h);
+      $this->assertIsArray($h);
       $this->assertEquals(2, sizeof($h));
       $this->assertContains($this->arrayHeader[0], $h);
       $this->assertContains($this->arrayHeader[1], $h);
-      
+
    } // End function testGetExtraHeaders
 
 }


### PR DESCRIPTION
 ## Summary

  Upgrades PHPUnit from `4.8.*` to `^8.5.52` to address CVE-2026-24765, a HIGH severity vulnerability involving unsafe deserialization in PHPUnit's PHPT handling.

  Fixes: SUPP-56 / SECOPSVM-102

  ## Changes

  - **`composer.json`** — bumped `phpunit/phpunit` requirement from `4.8.*` to `^8.5.52`
  - **`phpunit.xml`** — added `<testsuites>` configuration block required by PHPUnit 8
  - **Test files** — migrated test suite to the PHPUnit 8 API:
    - Replaced `PHPUnit_Framework_TestCase` with `PHPUnit\Framework\TestCase`
    - Added `: void` return type to `setUp()` and `tearDown()` methods
    - Replaced deprecated `@expectedException` / `@expectedExceptionMessage` annotations with `$this->expectException()` / `$this->expectExceptionMessage()`
    - Replaced deprecated `assertInternalType('array', ...)` with `assertIsArray(...)`

  ## Test plan

  - [x] `composer install` completes without errors
  - [x] `./bin/phpunit` runs and all tests pass